### PR TITLE
Test/pointers

### DIFF
--- a/learnGoWithTests/pointers/go.mod
+++ b/learnGoWithTests/pointers/go.mod
@@ -1,0 +1,3 @@
+module github.com/alam/LearnGoWithTests/pointers
+
+go 1.24.4

--- a/learnGoWithTests/pointers/wallet.go
+++ b/learnGoWithTests/pointers/wallet.go
@@ -1,0 +1,22 @@
+package main
+
+import "fmt"
+
+type Bitcoin int
+
+func (b Bitcoin) String() string {
+	return fmt.Sprintf("%d BTC", b)
+}
+
+type Wallet struct {
+	balance Bitcoin
+}
+
+func (w *Wallet) Deposit(amount Bitcoin) {
+	fmt.Printf("address of balance in deposit is %p\n", &w.balance)
+	w.balance += amount
+}
+
+func (w *Wallet) Balance() Bitcoin {
+	return w.balance
+}

--- a/learnGoWithTests/pointers/wallet.go
+++ b/learnGoWithTests/pointers/wallet.go
@@ -24,10 +24,11 @@ func (w *Wallet) Balance() Bitcoin {
 	return w.balance
 }
 
+var ErrInsufficientFunds = errors.New("cannot withdraw, insufficient funds")
 
 func (w *Wallet) Withdraw(amount Bitcoin) error {
 	if amount > w.balance {
-		return errors.New("oh no, not enough funds")
+		return ErrInsufficientFunds
 	}
 
 	w.balance -= amount

--- a/learnGoWithTests/pointers/wallet.go
+++ b/learnGoWithTests/pointers/wallet.go
@@ -1,6 +1,9 @@
 package main
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type Bitcoin int
 
@@ -19,4 +22,14 @@ func (w *Wallet) Deposit(amount Bitcoin) {
 
 func (w *Wallet) Balance() Bitcoin {
 	return w.balance
+}
+
+
+func (w *Wallet) Withdraw(amount Bitcoin) error {
+	if amount > w.balance {
+		return errors.New("oh no, not enough funds")
+	}
+
+	w.balance -= amount
+	return nil
 }

--- a/learnGoWithTests/pointers/wallet_test.go
+++ b/learnGoWithTests/pointers/wallet_test.go
@@ -6,40 +6,44 @@ import (
 
 func TestWallet(t *testing.T) {
 
-	assertBalance := func(t testing.TB, wallet Wallet, want Bitcoin) {
-		t.Helper()
-		got := wallet.Balance()
-
-		if got != want {
-			t.Errorf("got %s want %s", got, want)
-		}
-	}
-
-	assertError := func(t testing.TB, err error) {
-		t.Helper()
-		if err == nil {
-			t.Error("wanted an error but didn't get one")
-		}
-	}
-
 	t.Run("deposit", func(t *testing.T) {
 		wallet := Wallet{}
 		wallet.Deposit(Bitcoin(10))
 		assertBalance(t, wallet, Bitcoin(10))
 	})
 
-	t.Run("withdraw", func(t *testing.T) {
+	t.Run("withdraw with funds", func(t *testing.T) {
 		wallet := Wallet{balance: Bitcoin(20)}
 		wallet.Withdraw(Bitcoin(5))
 		assertBalance(t, wallet, Bitcoin(15))
 	})
 
 	t.Run("withdraw insufficient funds", func(t *testing.T) {
-		startingBalance := Bitcoin(20)
-		wallet := Wallet{startingBalance}
+		wallet := Wallet{Bitcoin(20)}
 		err := wallet.Withdraw(Bitcoin(100))
 
-		assertError(t, err)
-		assertBalance(t, wallet, startingBalance)
+		assertError(t, err, ErrInsufficientFunds)
+		assertBalance(t, wallet, Bitcoin(20))
 	})
+}
+
+func assertBalance(t testing.TB, wallet Wallet, want Bitcoin) {
+	t.Helper()
+	got := wallet.Balance()
+
+	if got != want {
+		t.Errorf("got %s want %s", got, want)
+	}
+}
+
+func assertError(t testing.TB, got error, want error) {
+	t.Helper()
+
+	if got == nil {
+		t.Fatal("didn't get an error but wanted one")
+	}
+
+	if got != want {
+		t.Errorf("got %s want %s", got, want)
+	}
 }

--- a/learnGoWithTests/pointers/wallet_test.go
+++ b/learnGoWithTests/pointers/wallet_test.go
@@ -1,21 +1,45 @@
 package main
 
 import (
-	"fmt"
 	"testing"
 )
 
 func TestWallet(t *testing.T) {
-	wallet := Wallet{}
 
-	wallet.Deposit(Bitcoin(10))
+	assertBalance := func(t testing.TB, wallet Wallet, want Bitcoin) {
+		t.Helper()
+		got := wallet.Balance()
 
-	got := wallet.Balance()
-	fmt.Printf("address of balance in test is %p\n", &wallet.balance)
-
-	want := Bitcoin(10)
-
-	if got != want {
-		t.Errorf("got %d want %d", got, want)
+		if got != want {
+			t.Errorf("got %s want %s", got, want)
+		}
 	}
+
+	assertError := func(t testing.TB, err error) {
+		t.Helper()
+		if err == nil {
+			t.Error("wanted an error but didn't get one")
+		}
+	}
+
+	t.Run("deposit", func(t *testing.T) {
+		wallet := Wallet{}
+		wallet.Deposit(Bitcoin(10))
+		assertBalance(t, wallet, Bitcoin(10))
+	})
+
+	t.Run("withdraw", func(t *testing.T) {
+		wallet := Wallet{balance: Bitcoin(20)}
+		wallet.Withdraw(Bitcoin(5))
+		assertBalance(t, wallet, Bitcoin(15))
+	})
+
+	t.Run("withdraw insufficient funds", func(t *testing.T) {
+		startingBalance := Bitcoin(20)
+		wallet := Wallet{startingBalance}
+		err := wallet.Withdraw(Bitcoin(100))
+
+		assertError(t, err)
+		assertBalance(t, wallet, startingBalance)
+	})
 }

--- a/learnGoWithTests/pointers/wallet_test.go
+++ b/learnGoWithTests/pointers/wallet_test.go
@@ -1,0 +1,21 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestWallet(t *testing.T) {
+	wallet := Wallet{}
+
+	wallet.Deposit(Bitcoin(10))
+
+	got := wallet.Balance()
+	fmt.Printf("address of balance in test is %p\n", &wallet.balance)
+
+	want := Bitcoin(10)
+
+	if got != want {
+		t.Errorf("got %d want %d", got, want)
+	}
+}

--- a/learnGoWithTests/structs/go.mod
+++ b/learnGoWithTests/structs/go.mod
@@ -1,0 +1,3 @@
+module github.com/alam/LearnGoWithTests/structs
+
+go 1.24.4

--- a/learnGoWithTests/structs/shapes.go
+++ b/learnGoWithTests/structs/shapes.go
@@ -3,3 +3,7 @@ package main
 func Perimeter(width float64, height float64) float64 {
 	return 2 * (width + height)
 }
+
+func Area(width float64, height float64) float64 {
+	return width * height
+}

--- a/learnGoWithTests/structs/shapes.go
+++ b/learnGoWithTests/structs/shapes.go
@@ -1,0 +1,5 @@
+package main
+
+func Perimeter(width float64, height float64) float64 {
+	return 2 * (width + height)
+}

--- a/learnGoWithTests/structs/shapes.go
+++ b/learnGoWithTests/structs/shapes.go
@@ -1,9 +1,14 @@
 package main
 
-func Perimeter(width float64, height float64) float64 {
-	return 2 * (width + height)
+type Rectangle struct {
+	Width float64
+	Height float64
 }
 
-func Area(width float64, height float64) float64 {
-	return width * height
+func Perimeter(rectangle Rectangle) float64 {
+	return 2 * (rectangle.Width + rectangle.Height)
+}
+
+func Area(rectangle Rectangle) float64 {
+	return rectangle.Width * rectangle.Height
 }

--- a/learnGoWithTests/structs/shapes.go
+++ b/learnGoWithTests/structs/shapes.go
@@ -2,6 +2,10 @@ package main
 
 import "math"
 
+type Shape interface {
+	Area() float64
+}
+
 type Rectangle struct {
 	Width float64
 	Height float64

--- a/learnGoWithTests/structs/shapes.go
+++ b/learnGoWithTests/structs/shapes.go
@@ -26,3 +26,12 @@ func (c Circle) Area() float64 {
 func Perimeter(rectangle Rectangle) float64 {
 	return 2 * (rectangle.Width + rectangle.Height)
 }
+
+type Tringle struct {
+	Base   float64
+	Height float64
+}
+
+func (t Tringle) Area() float64 {
+	return 0.5 * t.Base * t.Height
+}

--- a/learnGoWithTests/structs/shapes.go
+++ b/learnGoWithTests/structs/shapes.go
@@ -1,14 +1,24 @@
 package main
 
+import "math"
+
 type Rectangle struct {
 	Width float64
 	Height float64
 }
 
-func Perimeter(rectangle Rectangle) float64 {
-	return 2 * (rectangle.Width + rectangle.Height)
+func (r Rectangle) Area() float64 {
+	return r.Width * r.Height
 }
 
-func Area(rectangle Rectangle) float64 {
-	return rectangle.Width * rectangle.Height
+type Circle struct {
+	Radius float64
+}
+
+func (c Circle) Area() float64 {
+	return math.Pi * c.Radius * c.Radius
+}
+
+func Perimeter(rectangle Rectangle) float64 {
+	return 2 * (rectangle.Width + rectangle.Height)
 }

--- a/learnGoWithTests/structs/shapes_test.go
+++ b/learnGoWithTests/structs/shapes_test.go
@@ -1,0 +1,12 @@
+package main
+
+import "testing"
+
+func TestPerimeter(t *testing.T) {
+	got := Perimeter(10.0, 10.0)
+	want := 40.0
+
+	if got != want {
+		t.Errorf("got %.2f, want %.2f", got, want)
+	}
+}

--- a/learnGoWithTests/structs/shapes_test.go
+++ b/learnGoWithTests/structs/shapes_test.go
@@ -3,7 +3,8 @@ package main
 import "testing"
 
 func TestPerimeter(t *testing.T) {
-	got := Perimeter(10.0, 10.0)
+	rectangle := Rectangle{10.0, 10.0}
+	got := Perimeter(rectangle)
 	want := 40.0
 
 	if got != want {
@@ -12,7 +13,8 @@ func TestPerimeter(t *testing.T) {
 }
 
 func AreaTest(t *testing.T) {
-	got := Area(12.0, 6.0)
+	rectangle := Rectangle{12.0, 6.0}
+	got := Area(rectangle)
 	want := 72.0
 
 	if got != want {

--- a/learnGoWithTests/structs/shapes_test.go
+++ b/learnGoWithTests/structs/shapes_test.go
@@ -13,23 +13,22 @@ func TestPerimeter(t *testing.T) {
 }
 
 func AreaTest(t *testing.T) {
-	t.Run("rectangles", func(t *testing.T) {
-		rectangle := Rectangle{12, 6}
-		got := rectangle.Area()
-		want := 72.0
 
+	checkArea := func(t testing.TB, shape Shape, want float64) {
+		t.Helper()
+		got := shape.Area()
 		if got != want {
 			t.Errorf("got %g, want %g", got, want)
 		}
+	}
+
+	t.Run("rectangles", func(t *testing.T) {
+		rectangle := Rectangle{12, 6}
+		checkArea(t, rectangle, 72.0)
 	})
 
 	t.Run("circles", func(t *testing.T) {
 		circle := Circle{10}
-		got := circle.Area()
-		want := 314.16
-
-		if got != want {
-			t.Errorf("got %g, want %g", got, want)
-		}
+		checkArea(t, circle, 314.1592653589793)
 	})
 }

--- a/learnGoWithTests/structs/shapes_test.go
+++ b/learnGoWithTests/structs/shapes_test.go
@@ -13,11 +13,23 @@ func TestPerimeter(t *testing.T) {
 }
 
 func AreaTest(t *testing.T) {
-	rectangle := Rectangle{12.0, 6.0}
-	got := Area(rectangle)
-	want := 72.0
+	t.Run("rectangles", func(t *testing.T) {
+		rectangle := Rectangle{12, 6}
+		got := rectangle.Area()
+		want := 72.0
 
-	if got != want {
-		t.Errorf("got %.2f, want %.2f", got, want)
-	}
+		if got != want {
+			t.Errorf("got %g, want %g", got, want)
+		}
+	})
+
+	t.Run("circles", func(t *testing.T) {
+		circle := Circle{10}
+		got := circle.Area()
+		want := 314.16
+
+		if got != want {
+			t.Errorf("got %g, want %g", got, want)
+		}
+	})
 }

--- a/learnGoWithTests/structs/shapes_test.go
+++ b/learnGoWithTests/structs/shapes_test.go
@@ -10,3 +10,12 @@ func TestPerimeter(t *testing.T) {
 		t.Errorf("got %.2f, want %.2f", got, want)
 	}
 }
+
+func AreaTest(t *testing.T) {
+	got := Area(12.0, 6.0)
+	want := 72.0
+
+	if got != want {
+		t.Errorf("got %.2f, want %.2f", got, want)
+	}
+}

--- a/learnGoWithTests/structs/shapes_test.go
+++ b/learnGoWithTests/structs/shapes_test.go
@@ -14,21 +14,19 @@ func TestPerimeter(t *testing.T) {
 
 func AreaTest(t *testing.T) {
 
-	checkArea := func(t testing.TB, shape Shape, want float64) {
-		t.Helper()
-		got := shape.Area()
-		if got != want {
-			t.Errorf("got %g, want %g", got, want)
-		}
+	areaTests := []struct {
+		shape Shape
+		want  float64
+	}{
+		{Rectangle{Width: 12, Height: 6}, 72.0},
+		{Circle{Radius: 10}, 314.1592653589793},
+		{Tringle{Base: 10, Height: 5}, 25.0},
 	}
 
-	t.Run("rectangles", func(t *testing.T) {
-		rectangle := Rectangle{12, 6}
-		checkArea(t, rectangle, 72.0)
-	})
-
-	t.Run("circles", func(t *testing.T) {
-		circle := Circle{10}
-		checkArea(t, circle, 314.1592653589793)
-	})
+	for _, tt := range areaTests {
+		got := tt.shape.Area()
+		if got != tt.want {
+			t.Errorf("got %.2f, want %.2f", got, tt.want)
+		}
+	}
 }


### PR DESCRIPTION
Pointers
Go copies values when you pass them to functions/methods, so if you're writing a function that needs to mutate state you'll need it to take a pointer to the thing you want to change.

The fact that Go takes a copy of values is useful a lot of the time but sometimes you won't want your system to make a copy of something, in which case you need to pass a reference. Examples include referencing very large data structures or things where only one instance is necessary (like database connection pools).